### PR TITLE
Add OpenAPI annotations to enhance API documentation clarity

### DIFF
--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/AdminController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/AdminController.java
@@ -1,5 +1,7 @@
 package org.endeavourhealth.imapi.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.endeavourhealth.imapi.aws.AWSCognitoClient;
 import org.endeavourhealth.imapi.aws.UserNotFoundException;
@@ -27,7 +29,8 @@ public class AdminController {
   private static final Logger LOG = LoggerFactory.getLogger(AdminController.class);
   AWSCognitoClient awsCognitoClient = new AWSCognitoClient();
 
-  @GetMapping(value="/cognito/users")
+  @Operation(summary = "List Cognito users", description = "Retrieve a list of all Cognito users.")
+  @GetMapping(value = "/cognito/users")
   public List<String> listUsers() throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Admin.Cognito.users.GET")) {
       LOG.debug("getUsers");
@@ -35,14 +38,16 @@ public class AdminController {
     }
   }
 
+  @Operation(summary = "Get a Cognito user", description = "Retrieve a specific Cognito user by their username.")
   @GetMapping(value = "/cognito/user")
-  public User getUser(@RequestParam(name = "username") String username) throws IOException, UserNotFoundException {
+  public User getUser(@Parameter(description = "The username of the Cognito user to retrieve.") @RequestParam(name = "username") String username) throws IOException, UserNotFoundException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Admin.User.get")) {
       LOG.debug("getUser");
       return awsCognitoClient.adminGetUser(username);
     }
   }
 
+  @Operation(summary = "List Cognito groups", description = "Retrieve a list of all Cognito user groups.")
   @GetMapping(value = "/cognito/groups")
   public List<String> listGroups() throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Admin.Cognito.groups.GET")) {
@@ -51,48 +56,54 @@ public class AdminController {
     }
   }
 
+  @Operation(summary = "List users in Cognito group", description = "Retrieve a list of all users within a specific Cognito group.")
   @GetMapping(value = "/cognito/group/users")
-  public List<String> listUsersInGroup(@RequestParam("group") String group) throws IOException {
+  public List<String> listUsersInGroup(@Parameter(description = "The name of the Cognito group.") @RequestParam("group") String group) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Admin.Cognito.usersInGroup.GET")) {
       LOG.debug("getUsersInGroup");
       return awsCognitoClient.adminListUsersInGroup(group);
     }
   }
 
+  @Operation(summary = "Add user to Cognito group", description = "Add a specific user to a Cognito group.")
   @PostMapping(value = "/cognito/group/user")
-  public void addUserToGroup(@RequestBody CognitoGroupRequest cognitoGroupRequest) throws IOException {
+  public void addUserToGroup(@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The request payload containing the username and group name.") @RequestBody CognitoGroupRequest cognitoGroupRequest) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Admin.Cognito.addUserToGroup.POST")) {
       LOG.debug("addUserToGroup");
       awsCognitoClient.adminAddUserToGroup(cognitoGroupRequest.getUsername(), cognitoGroupRequest.getGroupName());
     }
   }
 
+  @Operation(summary = "Remove user from Cognito group", description = "Remove a specific user from a Cognito group.")
   @DeleteMapping(value = "/cognito/group/user")
-  public void removeUserFromGroup(@RequestBody CognitoGroupRequest cognitoGroupRequest) throws IOException {
+  public void removeUserFromGroup(@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The request payload containing the username and group name.") @RequestBody CognitoGroupRequest cognitoGroupRequest) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Admin.Cognito.removeUserFromGroup.DELETE")) {
       LOG.debug("removeUserFromGroup");
       awsCognitoClient.adminRemoveUserFromGroup(cognitoGroupRequest.getUsername(), cognitoGroupRequest.getGroupName());
     }
   }
 
+  @Operation(summary = "Delete Cognito user", description = "Delete a specific Cognito user by username.")
   @DeleteMapping(value = "cognito/user")
-  public void deleteUser(@RequestBody StringBody username) throws IOException {
+  public void deleteUser(@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The request payload containing the username.") @RequestBody StringBody username) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Admin.Cognito.deleteUser.DELETE")) {
       LOG.debug("deleteUser");
       awsCognitoClient.adminDeleteUser(username.getValue());
     }
   }
 
+  @Operation(summary = "Create Cognito user", description = "Create a new Cognito user.")
   @PostMapping(value = "cognito/user")
-  public User createUser(@RequestBody User user) throws IOException {
+  public User createUser(@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The user details to create.") @RequestBody User user) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Cognito.createUser.POST")) {
       LOG.debug("createUser");
       return awsCognitoClient.adminCreateUser(user);
     }
   }
 
+  @Operation(summary = "Reset Cognito user password", description = "Reset a specific user's password in Cognito.")
   @DeleteMapping(value = "cognito/user/resetPassword")
-  public void resetPassword(@RequestBody StringBody username) throws IOException {
+  public void resetPassword(@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "The username for which to reset the password.") @RequestBody StringBody username) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Admin.Cognito.user.resetPassword.DELETE")) {
       LOG.debug("resetPassword");
       awsCognitoClient.adminResetUserPassword(username.getValue());

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/CodeGenController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/CodeGenController.java
@@ -1,5 +1,7 @@
 package org.endeavourhealth.imapi.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.endeavourhealth.imapi.logic.service.CodeGenService;
@@ -25,6 +27,7 @@ public class CodeGenController {
   private static final Logger LOG = LoggerFactory.getLogger(CodeGenController.class);
   private final CodeGenService codeGenService = new CodeGenService();
 
+  @Operation(summary = "Get a list of code templates", description = "Retrieve a list of available code templates.")
   @GetMapping(value = "/public/codeTemplates", produces = "application/json")
   public List<String> getCodeTemplateList(HttpServletRequest request) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.CodeGen.CodeTemplates.GET")) {
@@ -33,25 +36,33 @@ public class CodeGenController {
     }
   }
 
+  @Operation(summary = "Get a specific code template", description = "Retrieve a specific code template by its name.")
   @GetMapping(value = "/public/codeTemplate", produces = "application/json")
-  public CodeGenDto getCodeTemplate(HttpServletRequest request, @RequestParam("templateName") String templateName) throws IOException {
+  public CodeGenDto getCodeTemplate(HttpServletRequest request,
+                                    @Parameter(description = "The name of the code template to retrieve") @RequestParam("templateName") String templateName) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.CodeGen.CodeTemplate.GET")) {
       LOG.debug("getCodeTemplate");
       return codeGenService.getCodeTemplate(templateName);
     }
   }
 
+  @Operation(summary = "Update a code template", description = "Update an existing code template.")
   @PostMapping(value = "/public/codeTemplate", produces = "application/json")
   @ResponseStatus(HttpStatus.ACCEPTED)
-  public void updateCodeTemplate(HttpServletRequest request, @RequestBody CodeGenDto codeGenDto) throws IOException {
+  public void updateCodeTemplate(HttpServletRequest request,
+                                 @Parameter(description = "The CodeGenDto object containing the details of the code template to update") @RequestBody CodeGenDto codeGenDto) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.CodeGen.CodeTemplate.POST")) {
       LOG.debug("updateCodeTemplate");
       codeGenService.updateCodeTemplate(codeGenDto.getName(), codeGenDto.getExtension(), codeGenDto.getCollectionWrapper(), codeGenDto.getDatatypeMap(), codeGenDto.getTemplate());
     }
   }
 
+  @Operation(summary = "Generate code", description = "Generate code based on the provided IRI, template name, and namespace.")
   @GetMapping(value = "/public/generateCode", produces = "application/json")
-  public HttpEntity<Object> generateCode(HttpServletRequest request, @RequestParam(name = "iri", required = false) String iri, @RequestParam("template") String templateName, @RequestParam("namespace") String namespace) throws IOException {
+  public HttpEntity<Object> generateCode(HttpServletRequest request,
+                                         @Parameter(description = "The IRI for which to generate code") @RequestParam(name = "iri", required = false) String iri,
+                                         @Parameter(description = "The name of the template to use for generating code") @RequestParam("template") String templateName,
+                                         @Parameter(description = "The namespace to use for generating code") @RequestParam("namespace") String namespace) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.CodeGen.GenerateCode.GET")) {
       LOG.debug("GenerateCode");
 

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/CognitoController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/CognitoController.java
@@ -1,5 +1,6 @@
 package org.endeavourhealth.imapi.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.endeavourhealth.imapi.aws.AWSCognitoClient;
@@ -26,6 +27,10 @@ public class CognitoController {
   private final RequestObjectService requestObjectService = new RequestObjectService();
 
   @GetMapping(value = "/public/config", produces = "application/json")
+  @Operation(
+    summary = "Get Cognito Configuration",
+    description = "Retrieves configuration details for AWS Cognito, including regions, identity pool, user pool, and web client."
+  )
   public String getConfig() {
     String region = Optional.ofNullable(System.getenv("COGNITO_REGION")).orElse("eu-west-2");
     String identity_pool = Optional.ofNullable(System.getenv("COGNITO_IDENTITY_POOL")).orElse("eu-west-2:a9f46df7-f27e-4cc5-827b-d573ecf20667");
@@ -38,7 +43,7 @@ public class CognitoController {
           "aws_cognito_identity_pool_id": "%s",
           "aws_cognito_region": "%s",
           "aws_user_pools_id": "%s",
-          "aws_user_pools_web_client_id": "%s",
+          "aws_cognito_web_client_id": "%s",
           "oauth": {},
           "aws_cognito_username_attributes": [],
           "aws_cognito_social_providers": [],
@@ -67,6 +72,10 @@ public class CognitoController {
   }
 
   @GetMapping(value = "/public/isEmailRegistered")
+  @Operation(
+    summary = "Check Email Registration",
+    description = "Checks if the provided email address is already registered in AWS Cognito."
+  )
   public boolean isEmailRegistered(@RequestParam("email") String email) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.COGNITO.isEmailRegistered.GET")) {
       LOG.debug("isEmailRegistered");
@@ -74,7 +83,11 @@ public class CognitoController {
     }
   }
 
-  @PostMapping(value = "/updateEmailVerified")
+  @PostMapping(value = "/updateEmailVerified", produces = "application/json", consumes = "application/json")
+  @Operation(
+    summary = "Update Email Verification Status",
+    description = "Updates the email verification status for the specified user in AWS Cognito."
+  )
   public void updateEmailVerified(HttpServletRequest httpServletRequest, @RequestBody BooleanBody verified) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.COGNITO.updateEmailVerified.POST")) {
       LOG.debug("updateEmailVerified");

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/ConceptController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/ConceptController.java
@@ -36,6 +36,7 @@ public class ConceptController {
   private final ConceptService conceptService = new ConceptService();
 
   @GetMapping(value = "/public/matchedFrom", produces = "application/json")
+  @Operation(summary = "Get matched terms from the specified entity", description = "Retrieves terms that are matched from the given entity IRI for further processing or analysis.")
   public Collection<SimpleMap> getMatchedFrom(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.MatchedFrom.GET")) {
       LOG.debug("getMatchedFrom");
@@ -44,6 +45,7 @@ public class ConceptController {
   }
 
   @GetMapping(value = "/public/matchedTo", produces = "application/json")
+  @Operation(summary = "Get matched terms to the specified entity", description = "Retrieves terms that are matched to the given entity IRI for further processing or analysis.")
   public Collection<SimpleMap> getMatchedTo(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.MatchedTo.GET")) {
       LOG.debug("getMatchedTo");
@@ -52,6 +54,7 @@ public class ConceptController {
   }
 
   @GetMapping("/public/termCode")
+  @Operation(summary = "Retrieve term codes for the specified entity", description = "Gets a list of term codes associated with the given entity IRI, including the option to include inactive codes.")
   public List<SearchTermCode> getTermCodes(@RequestParam(name = "iri") String iri, @RequestParam(name = "includeInactive") Optional<Boolean> includeInactive) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.TermCode.GET")) {
       LOG.debug("getTermCodes");
@@ -79,7 +82,8 @@ public class ConceptController {
       if (request.getEcl().isEmpty()) throw new IllegalArgumentException("Ecl cannot be empty");
       if (0 == request.getPage()) request.setPage(1);
       if (0 == request.getSize()) request.setSize(EntityService.MAX_CHILDREN);
-      if (request.getSchemeFilters().isEmpty()) request.setSchemeFilters(new ArrayList<>(Arrays.asList(IM.NAMESPACE, SNOMED.NAMESPACE)));
+      if (request.getSchemeFilters().isEmpty())
+        request.setSchemeFilters(new ArrayList<>(Arrays.asList(IM.NAMESPACE, SNOMED.NAMESPACE)));
       return conceptService.getSuperiorPropertiesBoolFocusPaged(request);
     }
   }
@@ -97,6 +101,7 @@ public class ConceptController {
   }
 
   @GetMapping(value = "/public/conceptContextMaps")
+  @Operation(summary = "Get concept context maps for the specified entity", description = "Retrieves mappings to various contexts for the given entity IRI, which can be used for contextual analysis.")
   public List<ConceptContextMap> getConceptContextMaps(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.ConceptContextMaps.GET")) {
       LOG.debug("getConceptContextMaps");

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/ConfigController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/ConfigController.java
@@ -1,6 +1,7 @@
 package org.endeavourhealth.imapi.controllers;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.endeavourhealth.imapi.config.ConfigManager;
 import org.endeavourhealth.imapi.utility.MetricsHelper;
@@ -29,6 +30,10 @@ public class ConfigController {
   ConfigManager configManager;
 
   @GetMapping(value = "public/monitoring")
+  @Operation(
+    summary = "Retrieve monitoring configuration",
+    description = "Fetches monitoring configuration details from the config manager"
+  )
   public String getMonitoring() throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Config.Monitoring.GET")) {
       LOG.debug("getMonitoring");

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/DataModelController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/DataModelController.java
@@ -1,6 +1,7 @@
 package org.endeavourhealth.imapi.controllers;
 
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.endeavourhealth.imapi.logic.service.DataModelService;
 import org.endeavourhealth.imapi.model.PropertyDisplay;
@@ -24,41 +25,73 @@ import java.util.List;
 @RequestScope
 public class DataModelController {
 
-  private final DataModelService dataModelService = new DataModelService();
   private static final Logger LOG = LoggerFactory.getLogger(DataModelController.class);
+  private final DataModelService dataModelService = new DataModelService();
 
+  @Operation(
+    summary = "Retrieve a node shape with data model properties",
+    description = "Fetches the data model properties for the given IRI."
+  )
   @GetMapping("/public/dataModelProperties")
-  public NodeShape getDataModelProperties(@RequestParam(name = "iri") String iri, @RequestParam(name = "parent", required = false) String parent) throws IOException {
+  public NodeShape getDataModelProperties(
+    @Parameter(description = "IRI of the data model") @RequestParam(name = "iri") String iri,
+    @Parameter(description = "Optional parent for context") @RequestParam(name = "parent", required = false) String parent
+  ) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.DataModelProperties.GET")) {
       LOG.debug("getDataModelProperties");
       return dataModelService.getDataModelDisplayProperties(iri);
     }
   }
 
+  @Operation(
+    summary = "Fetches the property display information",
+    description = "Returns a list of properties displayed for the given IRI."
+  )
   @GetMapping(value = "/public/propertiesDisplay")
-  public List<PropertyDisplay> getPropertiesDisplay(@RequestParam(name = "iri") String iri) throws IOException {
+  public List<PropertyDisplay> getPropertiesDisplay(
+    @Parameter(description = "IRI of the data model") @RequestParam(name = "iri") String iri
+  ) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.PropertiesDisplay.GET")) {
       LOG.debug("getPropertiesDisplay");
       return dataModelService.getPropertiesDisplay(iri);
     }
   }
 
+  @Operation(
+    summary = "Retrieve UI property for query builder",
+    description = "Returns the UI property metadata for a given data model IRI and property IRI."
+  )
   @GetMapping(value = "public/UIPropertyForQB")
-  public UIProperty getUIPropertyForQB(@RequestParam(name = "dmIri") String dmIri, @RequestParam(name = "propIri") String propIri) throws IOException {
+  public UIProperty getUIPropertyForQB(
+    @Parameter(description = "IRI of the data model") @RequestParam(name = "dmIri") String dmIri,
+    @Parameter(description = "IRI of the property") @RequestParam(name = "propIri") String propIri
+  ) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.GetUIPropertyForQB.GET")) {
       LOG.debug("getUIPropertyForQB");
       return dataModelService.getUIPropertyForQB(dmIri, propIri);
     }
   }
 
+  @Operation(
+    summary = "Retrieve data models from a property",
+    description = "Returns a list of data models that reference the given property IRI."
+  )
   @GetMapping(value = "/public/dataModels")
-   public List<TTIriRef> getDataModelsFromProperty(@RequestParam(name = "propIri") String propIri) {
-      LOG.debug("getDataModelsFromProperty");
-      return dataModelService.getDataModelsFromProperty(propIri);
+  public List<TTIriRef> getDataModelsFromProperty(
+    @Parameter(description = "IRI of the property") @RequestParam(name = "propIri") String propIri
+  ) {
+    LOG.debug("getDataModelsFromProperty");
+    return dataModelService.getDataModelsFromProperty(propIri);
   }
 
+  @Operation(
+    summary = "Check the type of a property",
+    description = "Determines the type of the property for the given IRI."
+  )
   @GetMapping(value = "public/checkPropertyType")
-  public String checkPropertyType(@RequestParam(name = "propertyIri") String iri) throws IOException {
+  public String checkPropertyType(
+    @Parameter(description = "IRI of the property") @RequestParam(name = "propertyIri") String iri
+  ) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.CheckPropertyType.GET")) {
       LOG.debug("checkPropertyType");
       return dataModelService.checkPropertyType(iri);

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/EclController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/EclController.java
@@ -1,13 +1,11 @@
 package org.endeavourhealth.imapi.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.endeavourhealth.imapi.logic.service.EclService;
 import org.endeavourhealth.imapi.model.customexceptions.EclFormatException;
 import org.endeavourhealth.imapi.model.eclBuilder.BoolGroup;
 import org.endeavourhealth.imapi.model.eclBuilder.EclBuilderException;
-import org.endeavourhealth.imapi.model.iml.Concept;
 import org.endeavourhealth.imapi.model.imq.Query;
 import org.endeavourhealth.imapi.model.imq.QueryException;
 import org.endeavourhealth.imapi.model.search.SearchResponse;
@@ -20,15 +18,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.annotation.RequestScope;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Set;
 import java.util.UnknownFormatConversionException;
-import java.util.zip.DataFormatException;
 
 @RestController
 @RequestMapping("api/ecl")
 @CrossOrigin(origins = "*")
-@Tag(name = "Ecl Controller")
+@Tag(name = "Ecl Controller", description = "Controller to handle ECL-related requests")
 @RequestScope
 public class EclController {
   private static final Logger LOG = LoggerFactory.getLogger(EclController.class);
@@ -36,6 +31,10 @@ public class EclController {
   private final EclService eclService = new EclService();
 
   @PostMapping("/public/ecl")
+  @Operation(
+    summary = "Retrieve ECL string",
+    description = "Generates an ECL string from the provided IMQ Query object"
+  )
   public String getEcl(@RequestBody Query inferred) throws QueryException, IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("ECL.Ecl.POST")) {
       LOG.debug("getEcl");
@@ -45,8 +44,8 @@ public class EclController {
 
   @PostMapping(value = "/public/eclSearch", consumes = "application/json", produces = "application/json")
   @Operation(
-    summary = "ECL search",
-    description = "Search entities using ECL string"
+    summary = "Execute an ECL search",
+    description = "Performs a search for entities based on the provided ECL string query"
   )
   public SearchResponse eclSearch(
     @RequestBody EclSearchRequest request
@@ -60,8 +59,8 @@ public class EclController {
 
   @PostMapping(value = "/public/eclFromQuery")
   @Operation(
-    summary = "Get ecl from query",
-    description = "MapObject an IM query to ecl"
+    summary = "Generate ECL text from Query",
+    description = "Converts an IM Query into an equivalent ECL string"
   )
   public String getECLFromQuery(@RequestBody Query query) throws QueryException, IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.ECL.EclFromQuery.POST")) {
@@ -71,8 +70,8 @@ public class EclController {
 
   @PostMapping(value = "/public/eclFromQueryWithNames")
   @Operation(
-    summary = "Get ecl from query",
-    description = "MapObject an IM query to ecl"
+    summary = "Generate ECL text with concept names",
+    description = "Converts an IM query to an ECL string while including named concepts"
   )
   public String getECLFromQueryWithNames(@RequestBody Query query) throws QueryException, IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.ECL.EclFromQueryWithNames.POST")) {
@@ -82,8 +81,8 @@ public class EclController {
 
   @PostMapping(value = "/public/queryFromEcl", consumes = "text/plain", produces = "application/json")
   @Operation(
-    summary = "Get IMQ query from ecl",
-    description = "Map ecl test to an IM query object"
+    summary = "Convert ECL to Query",
+    description = "Transforms a provided ECL string into an IM Query object"
   )
   public Query getQueryFromECL(@RequestBody String ecl) throws IOException, EclFormatException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.ECL.QueryFromEcl.POST")) {
@@ -94,7 +93,8 @@ public class EclController {
 
   @PostMapping(value = "public/eclBuilderFromQuery", produces = "application/json")
   @Operation(
-    summary = "Get ecl builder component objects from an imq query"
+    summary = "Build ECL from Query",
+    description = "Generates ECL builder component objects from an IM Query"
   )
   public BoolGroup getEclBuilderFromQuery(@RequestBody Query query) throws QueryException, EclBuilderException, IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.ECL.EclBuilderFromQuery.POST")) {
@@ -105,7 +105,8 @@ public class EclController {
 
   @PostMapping(value = "public/queryFromEclBuilder", produces = "application/json")
   @Operation(
-    summary = "Get query from ecl builder component objects"
+    summary = "Generate Query from ECL Builder",
+    description = "Converts ECL builder component objects into an IM Query"
   )
   public Query getQueryFromEclBuilder(@RequestBody BoolGroup boolGroup) throws IOException, EclBuilderException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.ECL.QueryFromEclBuilder.POST")) {
@@ -115,7 +116,8 @@ public class EclController {
 
   @PostMapping(value = "public/validateEcl", consumes = "text/plain", produces = "application/json")
   @Operation(
-    summary = "Checks that validity of an ecl string"
+    summary = "Validate ECL format",
+    description = "Checks if the provided ECL string is valid"
   )
   public Boolean validateEcl(@RequestBody String ecl) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.ECL.ValidateEcl.POST")) {

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/EntityController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/EntityController.java
@@ -1,5 +1,6 @@
 package org.endeavourhealth.imapi.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.xml.bind.ValidationException;
@@ -8,7 +9,10 @@ import org.endeavourhealth.imapi.filer.TTFilerException;
 import org.endeavourhealth.imapi.logic.exporters.ExcelSearchExporter;
 import org.endeavourhealth.imapi.logic.exporters.SearchTextFileExporter;
 import org.endeavourhealth.imapi.logic.service.*;
-import org.endeavourhealth.imapi.model.*;
+import org.endeavourhealth.imapi.model.EntityReferenceNode;
+import org.endeavourhealth.imapi.model.Namespace;
+import org.endeavourhealth.imapi.model.Pageable;
+import org.endeavourhealth.imapi.model.ValidatedEntity;
 import org.endeavourhealth.imapi.model.customexceptions.DownloadException;
 import org.endeavourhealth.imapi.model.customexceptions.OpenSearchException;
 import org.endeavourhealth.imapi.model.dto.GraphDto;
@@ -66,6 +70,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/partial", produces = "application/json")
+  @Operation(summary = "Get partial entity", description = "Fetches partial entity details using IRI and a set of predicates")
   public TTEntity getPartialEntity(@RequestParam(name = "iri") String iri, @RequestParam(name = "predicates") Set<String> predicates) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Partial.GET")) {
       LOG.debug("getPartialEntity");
@@ -74,6 +79,7 @@ public class EntityController {
   }
 
   @PostMapping(value = "/public/partials")
+  @Operation(summary = "Get partial entities", description = "Fetches partial details for multiple entities based on IRIs and predicates")
   public List<TTEntity> getPartialEntities(@RequestBody Map<String, Object> map) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Partials.POST")) {
       LOG.debug("getPartialEntities");
@@ -88,6 +94,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/fullEntity", produces = "application/json")
+  @Operation(summary = "Get full entity", description = "Fetches full entity details using IRI")
   public TTEntity getFullEntity(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.FullEntity.GET")) {
       LOG.debug("getFullEntity");
@@ -96,6 +103,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/partialBundle", produces = "application/json")
+  @Operation(summary = "Get partial entity bundle", description = "Fetches a partial entity bundle by IRI and a set of predicates")
   public TTBundle getPartialEntityBundle(@RequestParam(name = "iri") String iri, @RequestParam(name = "predicates") Set<String> predicates) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.PartialBundle.GET")) {
       LOG.debug("getPartialEntityBundle");
@@ -104,6 +112,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/children")
+  @Operation(summary = "Get entity children", description = "Fetches immediate child entities of the specified entity by IRI")
   public List<EntityReferenceNode> getEntityChildren(@RequestParam(name = "iri") String iri, @RequestParam(name = "schemeIris", required = false) List<String> schemeIris, @RequestParam(name = "page", required = false) Integer page, @RequestParam(name = "size", required = false) Integer size) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Children.GET")) {
       LOG.debug("getEntityChildren");
@@ -118,6 +127,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/asEntityReferenceNode")
+  @Operation(summary = "Get entity as reference node", description = "Fetches the specified entity as an EntityReferenceNode by IRI")
   public EntityReferenceNode getEntityAsEntityReferenceNode(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.AsEntityReferenceNode.GET")) {
       LOG.debug("getEntityAsEntityReferenceNode");
@@ -126,9 +136,9 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/childrenPaged")
+  @Operation(summary = "Get entity children with paging", description = "Fetches immediate children of the specified entity with pagination and total count")
   public Pageable<EntityReferenceNode> getEntityChildrenPagedWithTotalCount(@RequestParam(name = "iri") String iri, @RequestParam(name = "schemeIris", required = false) List<String> schemeIris, @RequestParam(name = "page", required = false) Integer page, @RequestParam(name = "size", required = false) Integer size) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.ChildrenPaged.GET")) {
-
       LOG.debug("getEntityChildrenPagedWithTotalCount");
       if (page == null && size == null) {
         page = 1;
@@ -139,6 +149,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/partialAndTotalCount")
+  @Operation(summary = "Get partial and total count", description = "Fetches partial results and provides total count for the given entity and predicate")
   public Pageable<TTIriRef> getPartialAndTotalCount(@RequestParam(name = "iri") String iri, @RequestParam(name = "predicate") String predicate, @RequestParam(name = "page", required = false) Integer page, @RequestParam(name = "size", required = false) Integer size, @RequestParam(name = "schemeIris", required = false) List<String> schemeIris) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.PartialAndTotalCount.GET")) {
       LOG.debug("getPartialAndTotalCount");
@@ -151,6 +162,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/downloadEntity")
+  @Operation(summary = "Download entity", description = "Downloads the specified entity as a JSON file")
   public HttpEntity<Object> downloadEntity(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.DownloadEntity.GET")) {
       LOG.debug("Download entity");
@@ -169,6 +181,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/parents")
+  @Operation(summary = "Get entity parents", description = "Fetches immediate parent entities of the specified entity by IRI")
   public List<EntityReferenceNode> getEntityParents(@RequestParam(name = "iri") String iri, @RequestParam(name = "schemeIris", required = false) List<String> schemeIris, @RequestParam(name = "page", required = false) Integer page, @RequestParam(name = "size", required = false) Integer size) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Parents.GET")) {
       LOG.debug("getEntityParents");
@@ -177,6 +190,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/usages")
+  @Operation(summary = "Get entity usages", description = "Fetches usage details of the specified entity using IRI with pagination options")
   public List<TTEntity> entityUsages(@RequestParam(name = "iri") String iri, @RequestParam(name = "page", required = false) Integer page, @RequestParam(name = "size", required = false) Integer size) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Usages.GET")) {
       LOG.debug("entityUsages");
@@ -185,6 +199,7 @@ public class EntityController {
   }
 
   @GetMapping("/public/usagesTotalRecords")
+  @Operation(summary = "Get total records for usages", description = "Fetches the total number of records for the usages of a specified entity by IRI")
   public Integer totalRecords(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.UsagesTotalRecords.GET")) {
       LOG.debug("totalRecords");
@@ -194,6 +209,7 @@ public class EntityController {
 
   @PostMapping(value = "/create")
   @PreAuthorize("hasAuthority('create')")
+  @Operation(summary = "Create entity", description = "Creates a new entity in the system with the provided details")
   public TTEntity createEntity(@RequestBody TTEntity entity, HttpServletRequest request) throws TTFilerException, IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Create.POST")) {
       LOG.debug("createEntity");
@@ -204,6 +220,7 @@ public class EntityController {
 
   @PostMapping(value = "/update")
   @PreAuthorize("hasAuthority('edit')")
+  @Operation(summary = "Update entity", description = "Updates an existing entity with the provided details")
   public TTEntity updateEntity(@RequestBody TTEntity entity, HttpServletRequest request) throws TTFilerException, IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Update.POST")) {
       LOG.debug("updateEntity");
@@ -213,6 +230,7 @@ public class EntityController {
   }
 
   @GetMapping("/public/summary")
+  @Operation(summary = "Get entity summary", description = "Fetches a summary of the search results for the specified entity by IRI")
   public SearchResultSummary getSummary(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Summary.GET")) {
       LOG.debug("getSummary");
@@ -221,6 +239,7 @@ public class EntityController {
   }
 
   @GetMapping("/public/namespaces")
+  @Operation(summary = "Get all namespaces", description = "Fetches a list of namespaces available in the system")
   public List<Namespace> getNamespaces() throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Namespaces.GET")) {
       LOG.debug("getNamespaces");
@@ -229,6 +248,7 @@ public class EntityController {
   }
 
   @PostMapping("/public/downloadSearchResults")
+  @Operation(summary = "Download search results", description = "Downloads search results in specified format (e.g., xlsx, csv, tsv) for the given query options.")
   public HttpEntity<Object> downloadSearchResults(@RequestBody DownloadByQueryOptions downloadByQueryOptions) throws IOException, OpenSearchException, URISyntaxException, ExecutionException, InterruptedException, DownloadException, QueryException, DataFormatException {
     try (MetricsTimer t = MetricsHelper.recordTime("API/Entity.DownloadSearchResults.POST")) {
       LOG.debug("downloadSearchResults");
@@ -265,6 +285,7 @@ public class EntityController {
   }
 
   @GetMapping("/public/folderPath")
+  @Operation(summary = "Get folder path", description = "Fetches the folder path of an entity specified by its IRI")
   public List<TTIriRef> getFolderPath(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.FolderPath.GET")) {
       LOG.debug("getFolderPath");
@@ -273,6 +294,7 @@ public class EntityController {
   }
 
   @GetMapping("/public/shortestParentHierarchy")
+  @Operation(summary = "Get shortest parent hierarchy", description = "Fetches the shortest parent hierarchy between an ancestor and a descendant by their IRIs")
   public List<TTIriRef> getShortestPathBetweenNodes(@RequestParam(name = "ancestor") String ancestor, @RequestParam(name = "descendant") String descendant) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.ShortestParentHierarchy.GET")) {
       LOG.debug("getShortestPathBetweenNodes");
@@ -281,6 +303,7 @@ public class EntityController {
   }
 
   @GetMapping("/public/iriExists")
+  @Operation(summary = "Check if IRI exists", description = "Checks if a specified IRI exists in the system")
   public Boolean iriExists(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.IriExists.GET")) {
       LOG.debug("iriExists");
@@ -289,6 +312,7 @@ public class EntityController {
   }
 
   @GetMapping("/public/entityByPredicateExclusions")
+  @Operation(summary = "Get entity by predicate exclusions", description = "Fetches an entity details using IRI, excluding specified predicates")
   public TTEntity getEntityByPredicateExclusions(@RequestParam(name = "iri") String iri, @RequestParam(name = "predicates") Set<String> predicates) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.EntityByPredicateExclusions.GET")) {
       LOG.debug("getEntityByPredicateExclusions");
@@ -297,6 +321,7 @@ public class EntityController {
   }
 
   @GetMapping("/public/bundleByPredicateExclusions")
+  @Operation(summary = "Get bundle by predicate exclusions", description = "Fetches a bundle of entities identified by IRI, excluding specified predicates")
   public TTBundle getBundleByPredicateExclusions(@RequestParam(name = "iri") String iri, @RequestParam(name = "predicates") Set<String> predicates) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.BundleByPredicateExclusions.GET")) {
       LOG.debug("getBundleByPredicateExclusions");
@@ -305,6 +330,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/predicates")
+  @Operation(summary = "Get predicates of an entity", description = "Fetches the predicates associated with a specified entity IRI")
   public Set<String> getPredicates(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Predicates.GET")) {
       LOG.debug("getPredicates");
@@ -313,6 +339,7 @@ public class EntityController {
   }
 
   @PostMapping(value = "/public/validatedEntity")
+  @Operation(summary = "Get validated entities by codes", description = "Fetches a list of validated entities for the provided SNOMED codes")
   public List<ValidatedEntity> getValidatedEntitiesBySnomedCodes(@RequestBody List<String> codes) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.ValidatedEntity.POST")) {
       LOG.debug("getValidatedEntitiesBySnomedCodes");
@@ -321,6 +348,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/detailsDisplay")
+  @Operation(summary = "Get entity details display", description = "Fetches the detailed display information for an entity specified by its IRI")
   public TTBundle getDetailsDisplay(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.DetailsDisplay.GET")) {
       LOG.debug("getDetailsDisplay");
@@ -329,6 +357,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/detailsDisplay/loadMore")
+  @Operation(summary = "Load more details display", description = "Fetches additional details for an entity, based on a predicate and pagination options")
   public TTBundle getDetailsDisplayLoadMore(
     @RequestParam(name = "iri") String iri,
     @RequestParam(name = "predicate") String predicate,
@@ -342,6 +371,7 @@ public class EntityController {
   }
 
   @PostMapping(value = "/public/validate")
+  @Operation(summary = "Validate entity", description = "Validates an entity using the provided validation request details")
   public EntityValidationResponse validateEntity(@RequestBody EntityValidationRequest request) throws IOException, ValidationException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.validate.POST")) {
       LOG.debug("validateEntity");
@@ -350,6 +380,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/type/entities")
+  @Operation(summary = "Get entities by type", description = "Fetches entities that match the specified type IRI")
   public List<TTIriRef> getEntitiesByType(@RequestParam(name = "iri") String typeIri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Predicates.GET")) {
       LOG.debug("getEntitiesByType");
@@ -358,6 +389,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/schemes")
+  @Operation(summary = "Get schemes with prefixes", description = "Fetches schemes and their prefixes available in the system")
   public Map<String, Namespace> getSchemesWithPrefixes() throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.SchemesWithPrefixes.GET")) {
       LOG.debug("getSchemesWithPrefixes");
@@ -366,6 +398,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/xmlSchemaDataTypes")
+  @Operation(summary = "Get XML schema data types", description = "Fetches the XML schema data types supported by the system")
   public Set<String> getXmlSchemaDataTypes() throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.XmlSchemaDataTypes.GET")) {
       LOG.debug("getXmlSchemaDataTypes");
@@ -374,6 +407,7 @@ public class EntityController {
   }
 
   @GetMapping(value = "/public/graph")
+  @Operation(summary = "Get graph data", description = "Fetches graph data for an entity specified by its IRI")
   public GraphDto getGraphData(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Graph.Graph.GET")) {
       LOG.debug("getGraphData");
@@ -382,6 +416,7 @@ public class EntityController {
   }
 
   @GetMapping("/public/history")
+  @Operation(summary = "Get provenance history", description = "Fetches the provenance history of an entity specified by its IRI")
   public List<TTEntity> getProvHistory(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Prov.History.GET")) {
       LOG.debug("getProvHistory");

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/FilerController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/FilerController.java
@@ -1,6 +1,7 @@
 package org.endeavourhealth.imapi.controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.endeavourhealth.imapi.filer.TTFilerException;
@@ -53,6 +54,7 @@ public class FilerController {
 
   @PostMapping("file/document")
   @PreAuthorize("hasAuthority('CONCEPT_WRITE')")
+  @Operation(summary = "Files a document and returns the task ID.")
   public ResponseEntity<Map<String, String>> fileDocument(@RequestBody TTDocument document, HttpServletRequest request) throws Exception {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Filer.File.Document.POST")) {
       LOG.debug("fileDocument");
@@ -75,6 +77,7 @@ public class FilerController {
   }
 
   @GetMapping("file/document/{taskId}")
+  @Operation(summary = "Retrieves the progress of a document file operation.")
   public ResponseEntity<Map<String, Integer>> getProgress(@PathVariable("taskId") String taskId) {
     Integer progress = filerService.getTaskProgress(taskId);
     Map<String, Integer> response = new HashMap<>();
@@ -84,6 +87,7 @@ public class FilerController {
 
   @PostMapping("file/entity")
   @PreAuthorize("hasAuthority('CONCEPT_WRITE')")
+  @Operation(summary = "Files an entity with specified graph and CRUD operation.")
   public ResponseEntity<Void> fileEntity(@RequestBody TTEntity entity, @RequestParam(name = "graph") String graph, @RequestParam(name = "crud") String crud, HttpServletRequest request) throws TTFilerException, IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Filer.File.Entity.POST")) {
       LOG.debug("fileEntity");
@@ -108,6 +112,7 @@ public class FilerController {
 
   @PostMapping("folder/move")
   @PreAuthorize("hasAuthority('CONCEPT_WRITE')")
+  @Operation(summary = "Moves an entity from one folder to another.")
   public ResponseEntity<ProblemDetailResponse> moveFolder(@RequestParam(name = "entity") String entityIri, @RequestParam(name = "oldFolder") String oldFolderIri, @RequestParam(name = "newFolder") String newFolderIri, HttpServletRequest request) throws Exception {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Filer.Folder.Move.POST")) {
       LOG.debug("moveFolder");
@@ -153,6 +158,7 @@ public class FilerController {
 
   @PostMapping("folder/add")
   @PreAuthorize("hasAuthority('CONCEPT_WRITE')")
+  @Operation(summary = "Adds an entity to a specified folder.")
   public ResponseEntity<ProblemDetailResponse> addToFolder(
     @RequestParam(name = "entity") String entityIri,
     @RequestParam(name = "folder") String folderIri,
@@ -184,6 +190,7 @@ public class FilerController {
 
   @PostMapping("folder/create")
   @PreAuthorize("hasAuthority('CONCEPT_WRITE')")
+  @Operation(summary = "Creates a new folder within a specified container.")
   public String createFolder(
     @RequestParam(name = "container") String container,
     @RequestParam(name = "name") String name,
@@ -241,6 +248,7 @@ public class FilerController {
 
   @GetMapping("deltas/download")
   @PreAuthorize("hasAuthority('IMAdmin')")
+  @Operation(summary = "Downloads deltas as a zip file.")
   public HttpEntity<Object> downloadDeltas() throws NullPointerException, IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Filer.Deltas.Download.GET")) {
       LOG.debug("downloadDeltas");

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/FunctionController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/FunctionController.java
@@ -1,22 +1,17 @@
 package org.endeavourhealth.imapi.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.endeavourhealth.imapi.logic.service.FunctionService;
 import org.endeavourhealth.imapi.model.iml.FunctionRequest;
-
 import org.endeavourhealth.imapi.utility.MetricsHelper;
 import org.endeavourhealth.imapi.utility.MetricsTimer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.annotation.RequestScope;
-
-
-import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("api/function")

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/GithubController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/GithubController.java
@@ -1,5 +1,6 @@
 package org.endeavourhealth.imapi.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.endeavourhealth.imapi.logic.service.GithubService;
 import org.endeavourhealth.imapi.model.customexceptions.ConfigException;
@@ -24,6 +25,7 @@ public class GithubController {
 
   GithubService githubService = new GithubService();
 
+  @Operation(summary = "Retrieve the latest GitHub release", description = "Gets the latest release information from the GitHub repository.")
   @GetMapping(value = "public/githubLatest")
   public GithubRelease getLatestRelease() throws IOException, ConfigException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Config.githubLatest.GET")) {
@@ -32,6 +34,7 @@ public class GithubController {
     }
   }
 
+  @Operation(summary = "Retrieve all GitHub releases", description = "Gets a list of all releases available in the GitHub repository.")
   @GetMapping(value = "public/githubAllReleases")
   public List<GithubRelease> getReleases() throws IOException, ConfigException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Config.githubReleases.GET")) {
@@ -40,6 +43,7 @@ public class GithubController {
     }
   }
 
+  @Operation(summary = "Update GitHub configuration", description = "Triggers an update to the GitHub repository configuration.")
   @PostMapping(value = "/updateGithubConfig")
   public void updateGithubConfig() throws IOException, InterruptedException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Config.githubConfig.UPDATE")) {

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/QueryController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/QueryController.java
@@ -27,7 +27,7 @@ import static org.endeavourhealth.imapi.model.tripletree.TTIriRef.iri;
 @RestController
 @RequestMapping("api/query")
 @CrossOrigin(origins = "*")
-@Tag(name = "QueryController")
+@Tag(name = "Query APIs", description = "APIs for querying the Information Model")
 @RequestScope
 public class QueryController {
   private static final Logger LOG = LoggerFactory.getLogger(QueryController.class);
@@ -81,11 +81,14 @@ public class QueryController {
   }
 
 
-
   @GetMapping(value = "/public/queryDisplay", produces = "application/json")
+  @Operation(
+    summary = "Describe a query",
+    description = "Retrieves the details of a query based on the given query IRI."
+  )
   public Query describeQuery(
     @RequestParam(name = "queryIri") String iri
-  ) throws IOException,QueryException  {
+  ) throws IOException, QueryException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Query.Display.GET")) {
       LOG.debug("getQueryDisplay");
       return queryService.describeQuery(iri);
@@ -93,8 +96,11 @@ public class QueryController {
   }
 
   @PostMapping("/public/queryDisplayFromQuery")
-  @Operation(summary = "get query view from imq as viewable object")
-  public Query describeQueryContent(@RequestBody Query query) throws IOException,QueryException {
+  @Operation(
+    summary = "Describe query content",
+    description = "Returns a query view, transforming an IMQ query into a viewable object."
+  )
+  public Query describeQueryContent(@RequestBody Query query) throws IOException, QueryException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Query.GetQuery.POST")) {
       LOG.debug("getQueryDisplay");
       return queryService.describeQuery(query);
@@ -102,7 +108,10 @@ public class QueryController {
   }
 
   @PostMapping("/public/sql")
-  @Operation(summary = "get sql from imq")
+  @Operation(
+    summary = "Generate SQL",
+    description = "Generates SQL from the provided IMQ query."
+  )
   public String getSQLFromIMQ(@RequestBody Query query) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Query.GetSQLFromIMQ.POST")) {
       LOG.debug("getSQLFromIMQ");
@@ -111,7 +120,10 @@ public class QueryController {
   }
 
   @GetMapping("/public/sql")
-  @Operation(summary = "get sql from imq iri")
+  @Operation(
+    summary = "Generate SQL from IRI",
+    description = "Generates SQL from the given IMQ query IRI."
+  )
   public String getSQLFromIMQIri(@RequestParam(name = "queryIri") String queryIri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Query.GetSQLFromIMQIri.GET")) {
       LOG.debug("getSQLFromIMQIri");

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/SetController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/SetController.java
@@ -7,12 +7,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.endeavourhealth.imapi.errorhandling.GeneralCustomException;
 import org.endeavourhealth.imapi.filer.TTFilerException;
 import org.endeavourhealth.imapi.logic.exporters.SetExporter;
+import org.endeavourhealth.imapi.logic.service.EntityService;
 import org.endeavourhealth.imapi.logic.service.RequestObjectService;
 import org.endeavourhealth.imapi.logic.service.SetService;
 import org.endeavourhealth.imapi.model.Pageable;
 import org.endeavourhealth.imapi.model.SetDiffObject;
 import org.endeavourhealth.imapi.model.customexceptions.DownloadException;
-import org.endeavourhealth.imapi.logic.service.EntityService;
 import org.endeavourhealth.imapi.model.iml.Concept;
 import org.endeavourhealth.imapi.model.imq.Node;
 import org.endeavourhealth.imapi.model.imq.QueryException;
@@ -24,7 +24,9 @@ import org.endeavourhealth.imapi.utility.MetricsTimer;
 import org.endeavourhealth.imapi.vocabulary.IM;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.annotation.RequestScope;
@@ -42,13 +44,13 @@ import java.util.Set;
 @RequestScope
 public class SetController {
 
-  private final EntityService entityService = new EntityService();
-  private final SetService setService = new SetService();
-  private final SetExporter setExporter = new SetExporter();
   private static final Logger LOG = LoggerFactory.getLogger(SetController.class);
   private static final String ATTACHMENT = "attachment;filename=\"";
   private static final String FORCE_DOWNLOAD = "force-download";
   private static final String APPLICATION = "application";
+  private final EntityService entityService = new EntityService();
+  private final SetService setService = new SetService();
+  private final SetExporter setExporter = new SetExporter();
   private final RequestObjectService reqObjService = new RequestObjectService();
 
   @GetMapping(value = "/publish")
@@ -61,6 +63,7 @@ public class SetController {
   }
 
   @GetMapping(value = "/public/members")
+  @Operation(summary = "Get entailed members", description = "Retrieves direct or entailed members from a given IRI with pagination support.")
   public Pageable<Node> get(@RequestParam(name = "iri") String iri, @RequestParam(name = "entailments", required = false) boolean entailments, @RequestParam(name = "page", required = false) Integer page, @RequestParam(name = "size", required = false) Integer size) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Set.EntailedMembers.GET")) {
       LOG.debug("getEntailedMembers");
@@ -68,7 +71,7 @@ public class SetController {
         page = 1;
         size = 10;
       }
-      return setService.getDirectOrEntailedMembersFromIri(iri, entailments,page, size);
+      return setService.getDirectOrEntailedMembersFromIri(iri, entailments, page, size);
     }
   }
 
@@ -93,6 +96,7 @@ public class SetController {
 
 
   @GetMapping("/public/subsets")
+  @Operation(summary = "Get subsets of entity", description = "Fetches all subsets for the given IRI.")
   public Set<TTIriRef> getSubsets(@RequestParam(name = "iri") String iri) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Subsets.GET")) {
       LOG.debug("getSubsets");
@@ -101,6 +105,7 @@ public class SetController {
   }
 
   @PostMapping(value = "public/distillation")
+  @Operation(summary = "Get semantic distillation", description = "Performs a semantic distillation process for the given list of concepts.")
   public List<TTIriRef> getDistillation(@RequestBody List<TTIriRef> conceptList) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Distillation.POST")) {
       LOG.debug("getDistillation");
@@ -109,25 +114,32 @@ public class SetController {
   }
 
   @GetMapping("/public/setExport")
-  public HttpEntity<Object> getSetExport(@RequestParam(name = "iri") String iri, @RequestParam(name = "definition", defaultValue = "false") boolean definition,
-                                         @RequestParam(name = "core", defaultValue = "false") boolean core,
-                                         @RequestParam(name = "legacy", defaultValue = "false") boolean legacy,
-                                         @RequestParam(name = "includeSubsets", defaultValue = "false") boolean subsets,
-                                         @RequestParam(name = "ownRow", defaultValue = "false") boolean ownRow,
-                                         @RequestParam(name = "im1id", defaultValue = "false") boolean im1id,
-                                         @RequestParam(name = "format") String format,
-                                         @RequestParam(name = "subsumptions", required=false) List<String> subsumptions,
-                                         @RequestParam(name = "schemes", defaultValue = "") List<String> schemes) throws DownloadException, IOException {
+  @Operation(
+    summary = "Export a set in the specified format",
+    description = "Exports a set of data according to the provided options, including various flags such as definition, core, legacy, subsets, etc."
+  )
+  public HttpEntity<Object> getSetExport(
+    @RequestParam(name = "iri") String iri,
+    @RequestParam(name = "definition", defaultValue = "false") boolean definition,
+    @RequestParam(name = "core", defaultValue = "false") boolean core,
+    @RequestParam(name = "legacy", defaultValue = "false") boolean legacy,
+    @RequestParam(name = "includeSubsets", defaultValue = "false") boolean subsets,
+    @RequestParam(name = "ownRow", defaultValue = "false") boolean ownRow,
+    @RequestParam(name = "im1id", defaultValue = "false") boolean im1id,
+    @RequestParam(name = "format") String format,
+    @RequestParam(name = "subsumptions", required = false) List<String> subsumptions,
+    @RequestParam(name = "schemes", defaultValue = "") List<String> schemes
+  ) throws DownloadException, IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.SetExport.GET")) {
       LOG.debug("getSetExport");
-      if (subsumptions==null){
-        subsumptions= List.of(IM.SUBSUMED_BY);
+      if (subsumptions == null) {
+        subsumptions = List.of(IM.SUBSUMED_BY);
       }
       HttpHeaders headers = new HttpHeaders();
       headers.setContentType(new MediaType(APPLICATION, FORCE_DOWNLOAD));
       headers.set(HttpHeaders.CONTENT_DISPOSITION, ATTACHMENT + "setExport." + format + "\"");
 
-      SetOptions setOptions = new SetOptions(iri, definition, core, legacy, subsets, schemes,subsumptions);
+      SetOptions setOptions = new SetOptions(iri, definition, core, legacy, subsets, schemes, subsumptions);
 
       try {
         byte[] setExport = setService.getSetExport(format, im1id, setOptions);
@@ -143,6 +155,7 @@ public class SetController {
   }
 
   @GetMapping(value = "/public/setDiff")
+  @Operation(summary = "Compare two sets", description = "Compares two sets identified by the provided IRIs and returns their differences.")
   public SetDiffObject getSetComparison(@RequestParam(name = "setIriA") Optional<String> setIriA, @RequestParam(name = "setIriB") Optional<String> setIriB) throws IOException, QueryException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Set.SetDiff.GET")) {
       LOG.debug("getSetComparison");
@@ -151,6 +164,7 @@ public class SetController {
   }
 
   @PostMapping(value = "/updateSubsetsFromSuper")
+  @Operation(summary = "Update subsets from super", description = "Updates subsets from a superclass according to the provided entity details.")
   @PreAuthorize("hasAuthority('edit') or hasAuthority('create')")
   public void updateSubsetsFromSuper(@RequestBody TTEntity entity, HttpServletRequest request) throws IOException, TTFilerException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.UpdateSubsetsFromSuper.POST")) {

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/StatusController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/StatusController.java
@@ -1,5 +1,6 @@
 package org.endeavourhealth.imapi.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.endeavourhealth.imapi.utility.EnvHelper;
 import org.endeavourhealth.imapi.utility.MetricsHelper;
@@ -23,6 +24,7 @@ import java.io.IOException;
 public class StatusController {
   private static final Logger LOG = LoggerFactory.getLogger(StatusController.class);
 
+  @Operation(summary = "Check the health status of the application")
   @GetMapping("/public/healthCheck")
   public ResponseEntity<String> healthCheck() throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Status.HealthCheck.GET")) {
@@ -31,6 +33,7 @@ public class StatusController {
     }
   }
 
+  @Operation(summary = "Check if the application is running in public mode")
   @GetMapping("/public/isPublicMode")
   public ResponseEntity<Boolean> isPublicMode() throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Status.isPublicMode.GET")) {
@@ -39,6 +42,7 @@ public class StatusController {
     }
   }
 
+  @Operation(summary = "Check if the application is running in development mode")
   @GetMapping("/public/isDevMode")
   public ResponseEntity<Boolean> isDevMode() throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Status.isDevMode.GET")) {

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/UserController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/UserController.java
@@ -1,6 +1,7 @@
 package org.endeavourhealth.imapi.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.endeavourhealth.imapi.errorhandling.GeneralCustomException;
@@ -23,13 +24,14 @@ import java.util.List;
 @RestController
 @RequestMapping("api/user")
 @CrossOrigin(origins = "*")
-@Tag(name = "UserController")
+@Tag(name = "UserController", description = "Controller for managing user preferences, accessibility features, and other user details.")
 @RequestScope
 public class UserController {
   private static final Logger LOG = LoggerFactory.getLogger(UserController.class);
   private final UserService userService = new UserService();
   private final RequestObjectService requestObjectService = new RequestObjectService();
 
+  @Operation(summary = "Get user preset", description = "Fetches the user preset configuration based on the request.")
   @GetMapping(value = "/preset")
   public String getUserPreset(HttpServletRequest request) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.User.Theme.GET")) {
@@ -39,6 +41,7 @@ public class UserController {
     }
   }
 
+  @Operation(summary = "Update user preset", description = "Updates the user preset configuration.")
   @PostMapping(value = "/preset", consumes = "text/plain")
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void updateUserPreset(HttpServletRequest request, @RequestBody String preset) throws IOException {
@@ -49,6 +52,7 @@ public class UserController {
     }
   }
 
+  @Operation(summary = "Get user primary color", description = "Fetches the primary color configuration for the user.")
   @GetMapping(value = "/primaryColor")
   public String getUserPrimaryColor(HttpServletRequest request) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.User.Theme.GET")) {
@@ -58,6 +62,7 @@ public class UserController {
     }
   }
 
+  @Operation(summary = "Update user primary color", description = "Updates the primary color configuration for the user.")
   @PostMapping(value = "/primaryColor", consumes = "text/plain")
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void updateUserPriaryColor(HttpServletRequest request, @RequestBody String color) throws IOException {
@@ -172,6 +177,7 @@ public class UserController {
     }
   }
 
+  @Operation(summary = "Update user organisations", description = "Updates the list of organisations for a user. Requires admin authority.")
   @PostMapping(value = "/organisations", produces = "application/json")
   @ResponseStatus(HttpStatus.ACCEPTED)
   @PreAuthorize("hasAuthority('IMAdmin')")

--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/WorkflowController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/WorkflowController.java
@@ -1,6 +1,7 @@
 package org.endeavourhealth.imapi.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.endeavourhealth.imapi.aws.UserNotFoundException;
@@ -17,94 +18,105 @@ import org.springframework.web.context.annotation.RequestScope;
 @RestController
 @RequestMapping("api/workflow")
 @CrossOrigin(origins = "*")
-@Tag(name="WorkflowController")
+@Tag(name = "WorkflowController")
 @RequestScope
 public class WorkflowController {
 
-    private static final Logger LOG = LoggerFactory.getLogger(WorkflowController.class);
-    private final WorkflowService workflowService = new WorkflowService();
-    private final RequestObjectService requestObjectService = new RequestObjectService();
+  private static final Logger LOG = LoggerFactory.getLogger(WorkflowController.class);
+  private final WorkflowService workflowService = new WorkflowService();
+  private final RequestObjectService requestObjectService = new RequestObjectService();
 
-    @PostMapping(value = "/createBugReport")
-    public void createBugReport(HttpServletRequest request, @RequestBody BugReport bugReport) throws JsonProcessingException, TaskFilerException, UserNotFoundException {
-        LOG.debug("createBugReport");
-        String id = requestObjectService.getRequestAgentId(request);
-        if (null == bugReport.getCreatedBy()) bugReport.setCreatedBy(id);
-        workflowService.createBugReport(bugReport);
-    }
+  @Operation(summary = "Create Bug Report", description = "Endpoint to create a new bug report.")
+  @PostMapping(value = "/createBugReport")
+  public void createBugReport(HttpServletRequest request, @RequestBody BugReport bugReport) throws JsonProcessingException, TaskFilerException, UserNotFoundException {
+    LOG.debug("createBugReport");
+    String id = requestObjectService.getRequestAgentId(request);
+    if (null == bugReport.getCreatedBy()) bugReport.setCreatedBy(id);
+    workflowService.createBugReport(bugReport);
+  }
 
-    @GetMapping(value = "/getBugReport", produces = "application/json")
-    @PreAuthorize("hasAuthority('IMAdmin')")
-    public BugReport getBugReport(@RequestParam(name = "id") String id) throws UserNotFoundException {
-        LOG.debug("getBugReport");
-        return workflowService.getBugReport(id);
-    }
+  @Operation(summary = "Get Bug Report", description = "Fetch a bug report using its unique ID.")
+  @GetMapping(value = "/getBugReport", produces = "application/json")
+  @PreAuthorize("hasAuthority('IMAdmin')")
+  public BugReport getBugReport(@RequestParam(name = "id") String id) throws UserNotFoundException {
+    LOG.debug("getBugReport");
+    return workflowService.getBugReport(id);
+  }
 
-    @GetMapping(value = "/getTasksByCreatedBy",produces = "application/json")
-    public WorkflowResponse getTasksByCreatedBy(HttpServletRequest request, @RequestParam(name = "page",required = false, defaultValue = "1") Integer page, @RequestParam(name = "size", required = false, defaultValue = "25") int size) throws JsonProcessingException, UserNotFoundException {
-        LOG.debug("getWorkflowsByCreatedBy");
-        WorkflowRequest wfRequest = new WorkflowRequest(request);
-        if (page != 0) wfRequest.setPage(page);
-        if (size != 0) wfRequest.setSize(size);
-        return workflowService.getTasksByCreatedBy(wfRequest);
-    }
+  @Operation(summary = "Get Tasks by Creator", description = "Retrieve tasks created by the currently authenticated user.")
+  @GetMapping(value = "/getTasksByCreatedBy", produces = "application/json")
+  public WorkflowResponse getTasksByCreatedBy(HttpServletRequest request, @RequestParam(name = "page", required = false, defaultValue = "1") Integer page, @RequestParam(name = "size", required = false, defaultValue = "25") int size) throws JsonProcessingException, UserNotFoundException {
+    LOG.debug("getWorkflowsByCreatedBy");
+    WorkflowRequest wfRequest = new WorkflowRequest(request);
+    if (page != 0) wfRequest.setPage(page);
+    if (size != 0) wfRequest.setSize(size);
+    return workflowService.getTasksByCreatedBy(wfRequest);
+  }
 
-    @GetMapping(value = "/getTasksByAssignedTo", produces = "application/json")
-    public WorkflowResponse getTasksByAssignedTo(HttpServletRequest request, @RequestParam(name = "page", required = false, defaultValue = "1") Integer page, @RequestParam(name = "size", required = false, defaultValue = "25") Integer size) throws JsonProcessingException, UserNotFoundException {
-        LOG.debug("getWorkflowsByAssignedTo");
-        WorkflowRequest wfRequest = new WorkflowRequest(request);
-        if (page != 0) wfRequest.setPage(page);
-        if (size != 0) wfRequest.setSize(size);
-        return workflowService.getTasksByAssignedTo(wfRequest);
-    }
+  @Operation(summary = "Get Tasks by Assignee", description = "Retrieve tasks assigned to the currently authenticated user.")
+  @GetMapping(value = "/getTasksByAssignedTo", produces = "application/json")
+  public WorkflowResponse getTasksByAssignedTo(HttpServletRequest request, @RequestParam(name = "page", required = false, defaultValue = "1") Integer page, @RequestParam(name = "size", required = false, defaultValue = "25") Integer size) throws JsonProcessingException, UserNotFoundException {
+    LOG.debug("getWorkflowsByAssignedTo");
+    WorkflowRequest wfRequest = new WorkflowRequest(request);
+    if (page != 0) wfRequest.setPage(page);
+    if (size != 0) wfRequest.setSize(size);
+    return workflowService.getTasksByAssignedTo(wfRequest);
+  }
 
-    @GetMapping(value = "/getUnassignedTasks", produces = "application/json")
-    @PreAuthorize("hasAuthority('IMAdmin')")
-    public WorkflowResponse getUnassignedTasks(HttpServletRequest request, @RequestParam(name = "page", required = false, defaultValue = "1") Integer page, @RequestParam(name = "size", required = false, defaultValue = "25") Integer size) throws JsonProcessingException, UserNotFoundException {
-        LOG.debug("getUnassignedTasks");
-        WorkflowRequest wfRequest = new WorkflowRequest(request);
-        if (page != 0) wfRequest.setPage(page);
-        if (size != 0) wfRequest.setSize(size);
-        return workflowService.getUnassignedTasks(wfRequest);
-    }
+  @Operation(summary = "Get Unassigned Tasks", description = "Retrieve tasks that are not assigned to any user.")
+  @GetMapping(value = "/getUnassignedTasks", produces = "application/json")
+  @PreAuthorize("hasAuthority('IMAdmin')")
+  public WorkflowResponse getUnassignedTasks(HttpServletRequest request, @RequestParam(name = "page", required = false, defaultValue = "1") Integer page, @RequestParam(name = "size", required = false, defaultValue = "25") Integer size) throws JsonProcessingException, UserNotFoundException {
+    LOG.debug("getUnassignedTasks");
+    WorkflowRequest wfRequest = new WorkflowRequest(request);
+    if (page != 0) wfRequest.setPage(page);
+    if (size != 0) wfRequest.setSize(size);
+    return workflowService.getUnassignedTasks(wfRequest);
+  }
 
-    @GetMapping(value = "/getTask", produces = "application/json")
-    public Task getTask(@RequestParam(name = "id") String id) throws UserNotFoundException {
-        LOG.debug("getTask");
-        return workflowService.getTask(id);
-    }
+  @Operation(summary = "Get a Task", description = "Fetch a task using its unique ID.")
+  @GetMapping(value = "/getTask", produces = "application/json")
+  public Task getTask(@RequestParam(name = "id") String id) throws UserNotFoundException {
+    LOG.debug("getTask");
+    return workflowService.getTask(id);
+  }
 
-    @DeleteMapping(value = "/deleteTask")
-    public void deleteTask(@RequestParam(name = "id") String id) throws TaskFilerException {
-        workflowService.deleteTask(id);
-    }
+  @Operation(summary = "Delete a Task", description = "Delete a task by its unique ID.")
+  @DeleteMapping(value = "/deleteTask")
+  public void deleteTask(@RequestParam(name = "id") String id) throws TaskFilerException {
+    workflowService.deleteTask(id);
+  }
 
-    @PostMapping(value = "/createRoleRequest")
-    public void createRoleRequest(HttpServletRequest request, @RequestBody RoleRequest roleRequest) throws JsonProcessingException, TaskFilerException, UserNotFoundException {
-        String id = requestObjectService.getRequestAgentId(request);
-        if (null == roleRequest.getCreatedBy()) roleRequest.setCreatedBy(id);
-        workflowService.createRoleRequest(roleRequest);
-    }
+  @Operation(summary = "Create Role Request", description = "Submit a role request created by the user.")
+  @PostMapping(value = "/createRoleRequest")
+  public void createRoleRequest(HttpServletRequest request, @RequestBody RoleRequest roleRequest) throws JsonProcessingException, TaskFilerException, UserNotFoundException {
+    String id = requestObjectService.getRequestAgentId(request);
+    if (null == roleRequest.getCreatedBy()) roleRequest.setCreatedBy(id);
+    workflowService.createRoleRequest(roleRequest);
+  }
 
-    @GetMapping(value = "/getRoleRequest", produces = "application/json")
-    @PreAuthorize("hasAuthority('IMAdmin')")
-    public RoleRequest getRoleRequest(@RequestParam(name = "id") String id) throws UserNotFoundException {
-        LOG.debug("getRoleRequest");
-        return workflowService.getRoleRequest(id);
-    }
+  @Operation(summary = "Get Role Request", description = "Retrieve a role request using its unique ID.")
+  @GetMapping(value = "/getRoleRequest", produces = "application/json")
+  @PreAuthorize("hasAuthority('IMAdmin')")
+  public RoleRequest getRoleRequest(@RequestParam(name = "id") String id) throws UserNotFoundException {
+    LOG.debug("getRoleRequest");
+    return workflowService.getRoleRequest(id);
+  }
 
-    @PostMapping(value = "/createEntityApproval")
-    public void createEntityApproval(HttpServletRequest request, @RequestBody EntityApproval entityApproval) throws JsonProcessingException, UserNotFoundException, TaskFilerException {
-        LOG.debug("createEntityApproval");
-        String id = requestObjectService.getRequestAgentId(request);
-        if (null == entityApproval.getCreatedBy()) entityApproval.setCreatedBy(id);
-        workflowService.createEntityApproval(entityApproval);
-    }
+  @Operation(summary = "Create Entity Approval", description = "Submit an approval request for an entity.")
+  @PostMapping(value = "/createEntityApproval")
+  public void createEntityApproval(HttpServletRequest request, @RequestBody EntityApproval entityApproval) throws JsonProcessingException, UserNotFoundException, TaskFilerException {
+    LOG.debug("createEntityApproval");
+    String id = requestObjectService.getRequestAgentId(request);
+    if (null == entityApproval.getCreatedBy()) entityApproval.setCreatedBy(id);
+    workflowService.createEntityApproval(entityApproval);
+  }
 
-    @PostMapping(value = "/updateTask")
-    public void updateTask(HttpServletRequest request, @RequestBody Task task) throws JsonProcessingException, UserNotFoundException, TaskFilerException {
-        LOG.debug("updateTask");
-        String id = requestObjectService.getRequestAgentId(request);
-        workflowService.updateTask(task, id);
-    }
+  @Operation(summary = "Update Task", description = "Update details of an existing task.")
+  @PostMapping(value = "/updateTask")
+  public void updateTask(HttpServletRequest request, @RequestBody Task task) throws JsonProcessingException, UserNotFoundException, TaskFilerException {
+    LOG.debug("updateTask");
+    String id = requestObjectService.getRequestAgentId(request);
+    workflowService.updateTask(task, id);
+  }
 }


### PR DESCRIPTION
This commit introduces @Operation and @Parameter annotations across multiple controllers to provide concise summaries and descriptions for each API endpoint. These enhancements improve the API's self-documenting capabilities, aiding developers in understanding and utilizing the endpoints effectively.