### PR TITLE
Add support for "includeComplexTypes" in CodeGen templates

### DIFF
--- a/api/src/main/java/org/endeavourhealth/imapi/controllers/CodeGenController.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/controllers/CodeGenController.java
@@ -53,7 +53,7 @@ public class CodeGenController {
                                  @Parameter(description = "The CodeGenDto object containing the details of the code template to update") @RequestBody CodeGenDto codeGenDto) throws IOException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.CodeGen.CodeTemplate.POST")) {
       LOG.debug("updateCodeTemplate");
-      codeGenService.updateCodeTemplate(codeGenDto.getName(), codeGenDto.getExtension(), codeGenDto.getCollectionWrapper(), codeGenDto.getDatatypeMap(), codeGenDto.getTemplate());
+      codeGenService.updateCodeTemplate(codeGenDto.getName(), codeGenDto.getExtension(), codeGenDto.getCollectionWrapper(), codeGenDto.getDatatypeMap(), codeGenDto.getTemplate(), codeGenDto.getComplexTypes());
     }
   }
 

--- a/api/src/main/java/org/endeavourhealth/imapi/dataaccess/CodeGenRepository.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/dataaccess/CodeGenRepository.java
@@ -3,6 +3,7 @@ package org.endeavourhealth.imapi.dataaccess;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
@@ -82,6 +83,8 @@ public class CodeGenRepository {
               case (CODE_TEMPLATE.EXTENSION) -> result.setExtension(bs.getValue("o").stringValue());
               case (RDFS.LABEL) -> result.setName(bs.getValue("o").stringValue());
               case (IM.DEFINITION) -> result.setTemplate(bs.getValue("o").stringValue());
+              case (CODE_TEMPLATE.INCLUDE_COMPLEX_TYPES) ->
+                result.setComplexTypes(((Literal) bs.getValue("o")).booleanValue());
               default -> {
                 break;
               }
@@ -95,7 +98,10 @@ public class CodeGenRepository {
     return result;
   }
 
-  public void updateCodeTemplate(String name, String extension, String wrapper, Map<String, String> dataTypeMap, String template) {
+  public void updateCodeTemplate(String name, String extension, String wrapper, Map<String, String> dataTypeMap, String template, Boolean complexTypes) {
+    if (null == complexTypes)
+      complexTypes = false;
+
     String deleteSparql = """
       DELETE WHERE {
         ?s ?p ?o
@@ -114,6 +120,7 @@ public class CodeGenRepository {
         ?iri ?definition ?template .
         ?iri ?typeMap ?datatypeMap .
         ?iri ?wrapperType ?wrapper .
+        ?iri ?includeComplex ?complexTypes .
       }
       WHERE {
         SELECT ?iri ?label ?extension {}
@@ -135,6 +142,8 @@ public class CodeGenRepository {
         qry2.setBinding("datatypeMap", literal(om.writeValueAsString(dataTypeMap)));
         qry2.setBinding("wrapperType", iri(CODE_TEMPLATE.WRAPPER));
         qry2.setBinding("wrapper", literal(wrapper));
+        qry2.setBinding("includeComplex", iri(CODE_TEMPLATE.INCLUDE_COMPLEX_TYPES));
+        qry2.setBinding("complexTypes", literal(complexTypes));
         qry2.execute();
       } catch (JsonProcessingException err) {
         LOG.error("Error updating codeTemplate", err);

--- a/api/src/main/java/org/endeavourhealth/imapi/logic/codegen/CodeGenJava.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/logic/codegen/CodeGenJava.java
@@ -58,7 +58,7 @@ public class CodeGenJava {
       PREFIX im: <http://endhealth.info/im#>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       PREFIX shacl: <http://www.w3.org/ns/shacl#>
-            
+      
       SELECT ?iri
       WHERE {
         ?iri (im:isContainedIn|rdfs:subClassOf)* im:HealthDataModel ;
@@ -100,7 +100,7 @@ public class CodeGenJava {
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       PREFIX shacl: <http://www.w3.org/ns/shacl#>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            
+      
       SELECT ?iri ?model ?comment ?propname ?type ?typeName ?dm ?min ?max ?propcomment ?order
       WHERE {
         ?iri shacl:property ?prop .
@@ -109,9 +109,9 @@ public class CodeGenJava {
         ?prop shacl:path ?propIri .
         ?propIri rdfs:label ?propname .
         OPTIONAL { ?prop shacl:order ?order }
-        OPTIONAL { ?prop shacl:class ?type }
+        # OPTIONAL { ?prop shacl:class ?type }
         OPTIONAL { ?prop shacl:datatype ?type }
-        OPTIONAL { ?prop shacl:node ?type }
+        # OPTIONAL { ?prop shacl:node ?type }
         OPTIONAL { ?type rdfs:label ?typeName }
         OPTIONAL { ?prop rdfs:comment ?propcomment }
         OPTIONAL { ?prop shacl:maxCount ?max }
@@ -199,11 +199,11 @@ public class CodeGenJava {
 
       os.write("""
         package org.endeavourhealth.imapi.logic.codegen;
-                
+        
         import org.endeavourhealth.imapi.model.tripletree.TTIriRef;
-                
+        
         import java.util.UUID;
-                
+        
         /**
         * Represents %s.
         """.formatted(modelNameSeparated));
@@ -213,8 +213,8 @@ public class CodeGenJava {
       os.write("""
         */
         public class %s extends IMDMBase<%s> {
-                
-                
+        
+        
           /**
           * %s constructor with identifier
           */
@@ -233,8 +233,8 @@ public class CodeGenJava {
         String propertyTypeName = getDataType(property.getDataType(), property.isModel(), false);
 
         os.write("""
-                      
-                      
+          
+          
             /**
             * Gets the %s of this %s
           """.formatted(propertyName, modelNameSeparated));
@@ -247,7 +247,7 @@ public class CodeGenJava {
               public %s get%s() {
                 return getProperty("%s");
               }
-                      
+            
               /**
               * Changes the %s of this %s
               * @param %s The new %s to set
@@ -277,7 +277,7 @@ public class CodeGenJava {
         );
         if (isArray) {
           os.write("""
-                          
+              
                 /**
                 * Adds the given %s to this %s
                 * @param %s The %s to add

--- a/api/src/main/java/org/endeavourhealth/imapi/logic/service/CodeGenService.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/logic/service/CodeGenService.java
@@ -32,8 +32,8 @@ public class CodeGenService {
     return codeGenRepository.getCodeTemplate(name);
   }
 
-  public void updateCodeTemplate(String name, String extension, String wrapper, Map<String, String> dataTypeMap, String template) {
-    codeGenRepository.updateCodeTemplate(name, extension, wrapper, dataTypeMap, template);
+  public void updateCodeTemplate(String name, String extension, String wrapper, Map<String, String> dataTypeMap, String template, Boolean complexTypes) {
+    codeGenRepository.updateCodeTemplate(name, extension, wrapper, dataTypeMap, template, complexTypes);
   }
 
   public HttpEntity<Object> generateCode(String iri, String templateName, String namespace) {

--- a/api/src/main/java/org/endeavourhealth/imapi/model/dto/CodeGenDto.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/model/dto/CodeGenDto.java
@@ -11,6 +11,7 @@ public class CodeGenDto {
   private String collectionWrapper;
   private Map<String, String> datatypeMap = new HashMap<>();
   private String template;
+  private Boolean complexTypes = false;
 
   public CodeGenDto() {
   }
@@ -65,6 +66,15 @@ public class CodeGenDto {
 
   public CodeGenDto setTemplate(String template) {
     this.template = template;
+    return this;
+  }
+
+  public Boolean getComplexTypes() {
+    return complexTypes;
+  }
+
+  public CodeGenDto setComplexTypes(Boolean complexTypes) {
+    this.complexTypes = complexTypes;
     return this;
   }
 

--- a/api/src/main/java/org/endeavourhealth/imapi/vocabulary/CODE_TEMPLATE.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/vocabulary/CODE_TEMPLATE.java
@@ -9,4 +9,5 @@ public class CODE_TEMPLATE {
     public static final String WRAPPER = CODE_TEMPLATE.NAMESPACE + "wrapper";
     public static final String DATATYPE_MAP = CODE_TEMPLATE.NAMESPACE + "datatypeMap";
     public static final String EXTENSION = CODE_TEMPLATE.NAMESPACE + "extension";
+    public static final String INCLUDE_COMPLEX_TYPES = CODE_TEMPLATE.NAMESPACE + "includeComplexTypes";
 }

--- a/api/vocab.json
+++ b/api/vocab.json
@@ -1077,7 +1077,6 @@
         "name": "DATATYPE_QUALIFIER",
         "value": "IM.NAMESPACE + \"datatypeQualifier\""
       }
-
     ]
   },
   {
@@ -2064,7 +2063,6 @@
         "name": "ALLOWABLE_RANGE_SUGGESTIONS",
         "value": "QUERY.NAMESPACE + \"AllowableRangeSuggestions\""
       },
-
       {
         "name": "GET_SUBCLASSES",
         "value": "QUERY.NAMESPACE + \"GetSubClasses\""
@@ -2335,6 +2333,10 @@
       {
         "name": "EXTENSION",
         "value": "CODE_TEMPLATE.NAMESPACE + \"extension\""
+      },
+      {
+        "name": "INCLUDE_COMPLEX_TYPES",
+        "value": "CODE_TEMPLATE.NAMESPACE + \"includeComplexTypes\""
       }
     ]
   }


### PR DESCRIPTION
Introduced the "includeComplexTypes" attribute to the CodeGen service, repository, and DTO. Updated related methods and SPARQL queries to accommodate this new field. This change enables handling of more complex data types in code generation processes.