### PR TITLE
Update conditional logic to include SHACL.CLASS check

### DIFF
--- a/api/src/main/java/org/endeavourhealth/imapi/logic/service/DataModelService.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/logic/service/DataModelService.java
@@ -73,7 +73,7 @@ public class DataModelService {
         TTIriRef inheritedFrom = propertyGroup.asNode().has(iri(IM.INHERITED_FROM))
           ? propertyGroup.asNode().get(iri(IM.INHERITED_FROM)).asIriRef()
           : null;
-        if (propertyGroup.asNode().has(iri(SHACL.PATH)) && (propertyGroup.asNode().has(iri(SHACL.DATATYPE)) || includeComplexTypes)) {
+        if (propertyGroup.asNode().has(iri(SHACL.PATH)) && (propertyGroup.asNode().has(iri(SHACL.DATATYPE)) || propertyGroup.asNode().has(iri(SHACL.CLASS)) || includeComplexTypes)) {
           getDataModelShaclProperties(properties, propertyGroup, inheritedFrom);
         }
       }


### PR DESCRIPTION
Enhanced the conditional statement to account for SHACL.CLASS when evaluating property groups. This ensures that class-based constraints are also considered alongside datatype and complex types, improving compliance with SHACL specifications.