### PR TITLE
Update EmailService to accept port as a String

### DIFF
--- a/api/src/main/java/org/endeavourhealth/imapi/filer/rdf4j/TaskFilerRdf4j.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/filer/rdf4j/TaskFilerRdf4j.java
@@ -36,7 +36,7 @@ public class TaskFilerRdf4j {
   private RepositoryConnection conn;
   private EmailService emailService = new EmailService(
     System.getenv("EMAILER_HOST"),
-    Integer.parseInt(System.getenv("EMAILER_PORT")),
+    System.getenv("EMAILER_PORT"),
     System.getenv("EMAILER_USERNAME"),
     System.getenv("EMAILER_PASSWORD")
   );

--- a/api/src/main/java/org/endeavourhealth/imapi/logic/service/EmailService.java
+++ b/api/src/main/java/org/endeavourhealth/imapi/logic/service/EmailService.java
@@ -18,7 +18,7 @@ public class EmailService {
   private String username;
   private String password;
 
-  public EmailService(String host, int port, String username, String password) {
+  public EmailService(String host, String port, String username, String password) {
     prop = new Properties();
     prop.put("mail.smtp.auth", true);
     prop.put("mail.smtp.starttls.enable", "true");


### PR DESCRIPTION
Changed the port parameter in EmailService from int to String to improve environment variable handling. This ensures compatibility with how port values are retrieved and avoids potential parsing errors.