### PR TITLE
refactor(security): simplify permission enforcement logic

### DIFF
--- a/src/main/java/org/endeavourhealth/imapi/controllers/CasbinController.java
+++ b/src/main/java/org/endeavourhealth/imapi/controllers/CasbinController.java
@@ -28,7 +28,6 @@ public class CasbinController {
 
   @GetMapping("public/hasPermission")
   public boolean hasPermission(HttpServletRequest request, @RequestParam(name = "resource") Resource resource, @RequestParam(name = "action") Action action) throws UserNotFoundException, UserAuthorisationException, JsonProcessingException {
-    User user = securityService.getUser(request);
-    return securityService.enforce(user, resource, action);
+    return securityService.enforce(resource, action, request);
   }
 }

--- a/src/main/java/org/endeavourhealth/imapi/controllers/EntityController.java
+++ b/src/main/java/org/endeavourhealth/imapi/controllers/EntityController.java
@@ -265,8 +265,8 @@ public class EntityController {
   public TTEntity createEntity(@RequestBody EditRequest editRequest, HttpServletRequest request) throws JsonProcessingException, UserAuthorisationException, TTFilerException, UserNotFoundException {
     try (MetricsTimer t = MetricsHelper.recordTime("API.Entity.Create.POST")) {
       log.debug("createEntity");
+      securityService.enforceWithError(Resource.ENTITY, Action.WRITE, request);
       User user = securityService.getUser(request);
-      securityService.enforceWithError(user, Resource.ENTITY, Action.WRITE);
       return filerService.createEntity(editRequest, user.getUsername());
     }
   }

--- a/src/main/java/org/endeavourhealth/imapi/logic/service/EndeavourSecurityService.kt
+++ b/src/main/java/org/endeavourhealth/imapi/logic/service/EndeavourSecurityService.kt
@@ -3,6 +3,8 @@ package org.endeavourhealth.imapi.logic.service
 import org.endeavourhealth.imapi.errorhandling.UserAuthorisationException
 import org.endeavourhealth.imapi.model.security.User
 import org.endeavourhealth.imapi.model.responses.LoginResponseES
+import org.endeavourhealth.imapi.model.security.Action
+import org.endeavourhealth.imapi.model.security.Resource
 import org.endeavourhealth.imapi.model.workflow.roleRequest.UserRole
 import org.endeavourhealth.imapi.utility.HttpRequestService
 import org.slf4j.LoggerFactory
@@ -216,5 +218,25 @@ class EndeavourSecurityService {
     )
     if (null != response) return response
     else throw UserAuthorisationException("Failed to admin update user")
+  }
+
+  fun enforce(ipAddress: String, sessionId: String, resource: Resource, action: Action): Boolean {
+    try {
+      val params = HashMap<String, String>()
+      params["sessionId"] = sessionId
+      params["object"] = resource.toString()
+      params["action"] = action.toString();
+      val headers = hashMapOf("X-CLIENT-IP" to ipAddress)
+      val response = httpRequestService.httpGet(
+        endeavourSecurityUrl + "/api/" + endeavourSecurityApplication + "/authz/hasPermission",
+        Boolean::class.java,
+        params,
+        headers
+      )
+      return response == true
+    } catch (e: Exception) {
+      log.warn("Failed to enforce user permissions", e)
+      return false
+    }
   }
 }

--- a/src/main/java/org/endeavourhealth/imapi/logic/service/SecurityService.java
+++ b/src/main/java/org/endeavourhealth/imapi/logic/service/SecurityService.java
@@ -164,23 +164,22 @@ public class SecurityService {
     }
   }*/
 
-  public void enforceWithError(User user, Resource resource, Action action) throws UserAuthorisationException {
+  public void enforceWithError(Resource resource, Action action, HttpServletRequest request) throws UserAuthorisationException {
     try {
-      boolean result = enforce(user, resource, action);
+      boolean result = enforce(resource, action, request);
       if (!result) {
-        throw new UserAuthorisationException(String.format("User %s not authorised to access resource %s with rights %s", user, resource, action));
+        throw new UserAuthorisationException(String.format("User not authorised to access resource %s with rights %s", resource, action));
       }
     } catch (Exception e) {
-      throw new UserAuthorisationException(String.format("User %s not authorised to access resource %s with rights %s", user, resource, action));
+      throw new UserAuthorisationException(String.format("User not authorised to access resource %s with rights %s", resource, action));
     }
   }
 
-  public boolean enforce(User user, Resource resource, Action action) throws UserAuthorisationException, JsonProcessingException {
-//    if (null == this.enforcer) {
-//      setupEnforcer();
-//    }
-    return true;
-    //return enforcer.enforce(user, resource.name(), action.name());
+  public boolean enforce(Resource resource, Action action, HttpServletRequest request) throws UserAuthorisationException, JsonProcessingException {
+    String ipAddress = getIpAddress(request);
+    String sessionId = getSessionId(request);
+
+    return endeavourSecurityService.enforce(ipAddress, sessionId, resource, action);
   }
 
 

--- a/src/main/java/org/endeavourhealth/imapi/utility/APIGuard.java
+++ b/src/main/java/org/endeavourhealth/imapi/utility/APIGuard.java
@@ -8,7 +8,6 @@ import org.endeavourhealth.imapi.errorhandling.UserNotFoundException;
 import org.endeavourhealth.imapi.logic.service.SecurityService;
 import org.endeavourhealth.imapi.model.security.Action;
 import org.endeavourhealth.imapi.model.security.Resource;
-import org.endeavourhealth.imapi.model.security.User;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -21,9 +20,7 @@ public class APIGuard {
   public boolean hasPermission(Resource resource, Action action) throws JsonProcessingException, UserAuthorisationException, UserNotFoundException {
     log.debug("Checking permission [{}]/[{}]", resource, action);
     ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
-    if (attributes == null) return false;
     HttpServletRequest request = attributes.getRequest();
-    User user = securityService.getUser(request);
-    return securityService.enforce(user, resource, action);
+    return securityService.enforce(resource, action, request);
   }
 }

--- a/src/main/java/org/endeavourhealth/imapi/utility/HttpRequestService.kt
+++ b/src/main/java/org/endeavourhealth/imapi/utility/HttpRequestService.kt
@@ -1,6 +1,7 @@
 package org.endeavourhealth.imapi.utility
 
 import org.apache.http.HttpException
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -9,6 +10,8 @@ import org.springframework.util.MultiValueMap
 import org.springframework.web.client.RestTemplate
 
 class HttpRequestService {
+  private val log = LoggerFactory.getLogger(HttpRequestService::class.java)
+
   companion object {
     @JvmStatic
     fun <T : Any, K> Map<T, K>.toMultiValueMap(): MultiValueMap<T, K> {


### PR DESCRIPTION
Removed unnecessary user object retrieval and streamlined security checks across API guard, entity controller, and casbin controller. Updated security service to accept request directly instead of user object. Implemented new enforce method in EndeavourSecurityService that uses IP address and session ID for authorization. Removed deprecated user-based enforcement methods and cleaned up related code.

The changes improve performance by eliminating redundant user lookups and centralize permission checking through HTTP requests to the security service, while maintaining the same authorization behavior.