### PR TITLE
debug(config): add logging to security and authentication components

### DIFF
--- a/src/main/java/org/endeavourhealth/imapi/config/SecurityConfig.java
+++ b/src/main/java/org/endeavourhealth/imapi/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.endeavourhealth.imapi.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.endeavourhealth.imapi.errorhandling.RestAccessDeniedHandler;
 import org.endeavourhealth.imapi.errorhandling.RestAuthenticationEntryPoint;
 import org.endeavourhealth.imapi.utility.EnvHelper;
@@ -21,12 +22,15 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
 
+@Slf4j
 @Configuration
 @EnableMethodSecurity(securedEnabled = true, jsr250Enabled = true)
 public class SecurityConfig {
 
   @Bean
   protected SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
+    log.debug("filterChain");
+
     http
       .cors(cors -> cors.configurationSource(corsFilter()))
       .csrf(AbstractHttpConfigurer::disable)
@@ -42,10 +46,12 @@ public class SecurityConfig {
 
   @Bean
   public UrlBasedCorsConfigurationSource corsFilter() {
-    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    log.debug("filterChain");
     CorsConfiguration config = new CorsConfiguration();
-    config.setAllowCredentials(true);
     String corsList = System.getenv().getOrDefault("CORS_ALLOWED_ORIGINS", "http://localhost:8082");
+    log.debug(corsList);
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    config.setAllowCredentials(true);
     config.setAllowedOrigins(Arrays.stream(corsList.split(",")).toList());
     config.setAllowedMethods(Arrays.asList("POST", "GET", "DELETE", "PUT", "OPTIONS"));
     config.setAllowedHeaders(Arrays.asList("X-Requested-From", "Origin", "Content-Type", "Accept", "Authorization"));
@@ -59,6 +65,7 @@ public class SecurityConfig {
   }
 
   protected void setRequestPermissions(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry req) {
+    log.debug("setRequestPermission");
     req.requestMatchers(HttpMethod.OPTIONS).permitAll();
 
     req.requestMatchers(HttpMethod.GET, "/").permitAll()
@@ -73,14 +80,19 @@ public class SecurityConfig {
 
 
     if (EnvHelper.isPublicMode()) {
+      log.info("Security mode: PUBLIC");
         req.requestMatchers(HttpMethod.GET, "/api/*/protected/**").permitAll()
         .requestMatchers(HttpMethod.POST, "/api/*/protected/**").permitAll();
+    } else {
+      log.info("Security mode: PRIVATE");
     }
 
     req.anyRequest().authenticated();
   }
 
   private HttpFirewall allowUrlEncodedSlashHttpFirewall() {
+    log.debug("allowUrlEncodedSlashHttpFirewall");
+
     StrictHttpFirewall firewall = new StrictHttpFirewall();
     firewall.setAllowUrlEncodedSlash(true);
     firewall.setAllowUrlEncodedDoubleSlash(true);
@@ -89,10 +101,12 @@ public class SecurityConfig {
   }
 
   RestAccessDeniedHandler accessDeniedHandler() {
+    log.debug("accessDeniedHandler");
     return new RestAccessDeniedHandler();
   }
 
   RestAuthenticationEntryPoint authenticationEntryPoint() {
+    log.debug("authenticationEntryPoint");
     return new RestAuthenticationEntryPoint();
   }
 }

--- a/src/main/java/org/endeavourhealth/imapi/config/SessionCookieAuthFilter.java
+++ b/src/main/java/org/endeavourhealth/imapi/config/SessionCookieAuthFilter.java
@@ -5,15 +5,16 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.endeavourhealth.imapi.logic.service.EndeavourSecurityService;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.security.sasl.AuthenticationException;
 import java.io.IOException;
 
 import static org.endeavourhealth.imapi.utility.IpExtractor.getIpAddress;
 
+@Slf4j
 public class SessionCookieAuthFilter extends OncePerRequestFilter {
   EndeavourSecurityService endeavourSecurityService = new EndeavourSecurityService();
 
@@ -24,6 +25,7 @@ public class SessionCookieAuthFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+    log.debug("doFilterInternal");
     String ip = getIpAddress(request);
     String sessionId = extractValueFromCookie(request, "session_id");
     if (sessionId != null) {

--- a/src/main/java/org/endeavourhealth/imapi/errorhandling/RestAccessDeniedHandler.java
+++ b/src/main/java/org/endeavourhealth/imapi/errorhandling/RestAccessDeniedHandler.java
@@ -2,6 +2,7 @@ package org.endeavourhealth.imapi.errorhandling;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -10,10 +11,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
+@Slf4j
 @Component
 public class RestAccessDeniedHandler implements AccessDeniedHandler {
   @Override
   public void handle(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, AccessDeniedException e) throws IOException {
+    log.debug("handle");
     httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     try (OutputStream out = httpServletResponse.getOutputStream()) {
       out.write("Access denied".getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
- Added debug logging to SecurityConfig for filterChain, corsFilter, setRequestPermissions, allowUrlEncodedSlashHttpFirewall, accessDeniedHandler, and authenticationEntryPoint methods
- Added debug logging to SessionCookieAuthFilter in doFilterInternal method
- Added debug logging to RestAccessDeniedHandler in handle method
- Added slf4j annotations to all modified classes for consistent logging support