### PR TITLE
refactor(api): sanitize filename in UPRN controller multipart upload

### DIFF
--- a/src/main/java/org/endeavourhealth/imapi/controllers/UPRNController.kt
+++ b/src/main/java/org/endeavourhealth/imapi/controllers/UPRNController.kt
@@ -143,9 +143,10 @@ open class UPRNController(
       securityService.requiresPermission(Permission(Resource.UPRN, listOf(UserRole.UPRN), listOf()), request);
 
       val fileContent = String(file.bytes)
+      val filename = file.originalFilename!!.replace(" ", "_");
       val boundary = "---" + System.currentTimeMillis()
       val multipartBody = "--$boundary\r\n" +
-        "Content-Disposition: form-data; name=\"file\"; filename=\"${file.originalFilename}\"\r\n" +
+        "Content-Disposition: form-data; name=\"file\"; filename=\"${filename}\"\r\n" +
         "Content-Type: text/plain\r\n\r\n" +
         "$fileContent\r\n" +
         "--$boundary--\r\n"


### PR DESCRIPTION
- Replaced spaces with underscores in `originalFilename` to ensure valid multipart form data construction
- Prevents potential issues with special characters in filenames during file upload